### PR TITLE
Update link to CLI release in post-install documentation

### DIFF
--- a/docs/docs/self-hosting/installation/post-install/index.md
+++ b/docs/docs/self-hosting/installation/post-install/index.md
@@ -159,7 +159,7 @@ apps](web-dev-settings.png){width=400px}
 ## Step 7: Configure Ente CLI
 
 You can download Ente CLI from
-[here](https://github.com/ente-io/ente/releases?q=tag%3Acli).
+[here](https://github.com/ente-io/ente/releases?q=tag%3Acli-v0).
 
 Check our [documentation](/self-hosting/administration/cli) on how to use Ente
 CLI for managing self-hosted instances.


### PR DESCRIPTION
The current link does not work as [search with tags][tags-search] does semver matching which is not what we want here.

[tags-search]: https://docs.github.com/en/repositories/releasing-projects-on-github/searching-a-repositorys-releases#search-syntax-for-searching-releases-in-a-repository